### PR TITLE
Dockerfile from local code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,17 @@
 FROM python:3.8-slim-buster
-MAINTAINER Marcin Sztolcman <marcin@urzenia.net>
+LABEL maintainer="Marcin Sztolcman <marcin@urzenia.net>"
 
+RUN python3 -m pip install pipenv
 RUN useradd --create-home sendria
-WORKDIR /home/sendria
 USER sendria
-RUN python3 -m pip install --user sendria==2.1.0
+COPY --chown=sendria:sendria . /home/sendria/sendria
+WORKDIR /home/sendria/sendria
+RUN pipenv lock --requirements > requirements.txt
+RUN python3 -m pip install --user -r requirements.txt
+RUN /home/sendria/.local/bin/webassets -m sendria.build_assets build
+RUN python3 setup.py install --user
+WORKDIR /home/sendria
 
 EXPOSE 1025 1080
 
 CMD ["/home/sendria/.local/bin/sendria", "--foreground", "--db=./mails.sqlite", "--smtp-ip=0.0.0.0", "--http-ip=0.0.0.0"]
-


### PR DESCRIPTION
I'm mostly using Docker and I think it would make more sense to build the image using the local version of the code.

Binding the image with the release on pypi hinders possibilities of "test builds". I've found myself having to change the Dockerfile to something similar to this PR while hacking the code.

The downside would be that you would have to checkout a specific tag before building the image in order to upload the correct version to docker hub.