### PR TITLE
Dockerfile improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
-FROM python:3.8-slim-buster
-MAINTAINER Marcin Sztolcman <marcin@urzenia.net>
+FROM python:3.10-alpine as build
+LABEL org.opencontainers.image.authors="Marcin Sztolcman <marcin@urzenia.net>"
 
-RUN useradd --create-home sendria
+ARG VERSION=2.2.2
+
+RUN addgroup -S sendria && adduser -S sendria -G sendria
 WORKDIR /home/sendria
 USER sendria
-RUN python3 -m pip install --user sendria==2.2.2
+RUN python3 -m pip install --user sendria==$VERSION
+ENV PATH="/home/sendria/.local/bin:$PATH"
 
 EXPOSE 1025 1080
 
-CMD ["/home/sendria/.local/bin/sendria", "--foreground", "--db=./mails.sqlite", "--smtp-ip=0.0.0.0", "--http-ip=0.0.0.0"]
-
+ENTRYPOINT [ "sendria", "--foreground", "--db=./mails.sqlite", "--smtp-ip=0.0.0.0", "--http-ip=0.0.0.0" ]


### PR DESCRIPTION
- use alpine because it’s slimmer than buster
- use entrypoint https://phoenixnap.com/kb/docker-cmd-vs-entrypoint
- extend path to easily invoke sendria binary
~~-add no-quit param as default~~ changed after CR
- allow to build any version using build-arg
- fix maintainer deprecation https://docs.docker.com/engine/reference/builder/#maintainer-deprecated