### PR TITLE
Added options to dockerfile to allow for use of commandline options

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,17 @@ LABEL org.opencontainers.image.authors="Marcin Sztolcman <marcin@urzenia.net>"
 
 ARG VERSION=2.2.2
 
+USER root
 RUN addgroup -S sendria && adduser -S sendria -G sendria
-WORKDIR /home/sendria
+RUN apk add --no-cache --upgrade bash
+RUN apk --update --no-cache --virtual build-dependencies add apache2-utils
 USER sendria
+WORKDIR /home/sendria
 RUN python3 -m pip install --user sendria==$VERSION
 ENV PATH="/home/sendria/.local/bin:$PATH"
+ENV SENDRIA_DATA_DIR="/home/sendria/data"
+ADD tools /home/sendria/tools
 
 EXPOSE 1025 1080
 
-ENTRYPOINT [ "sendria", "--foreground", "--db=./mails.sqlite", "--smtp-ip=0.0.0.0", "--http-ip=0.0.0.0" ]
+ENTRYPOINT [ "/home/sendria/tools/docker-entrypoint.sh" ]

--- a/tools/docker-entrypoint.sh
+++ b/tools/docker-entrypoint.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+declare -a cmd_opts
+
+# Make the data directory if it doesn't yet exist:
+if [[ ! -d $SENDRIA_DATA_DIR ]]; then
+  mkdir -p $SENDRIA_DATA_DIR
+fi
+
+### set any command line options that need setting:
+
+if [[ -n $DB_PATH ]] && [[ $DB_PATH =~ \.sqlite$ ]]; then
+  # Full path given
+  cmd_opts+=("--db=${DB_PATH}")
+elif [[ -n $DB_PATH ]] && [[ ! $DB_PATH =~ \.sqlite$ ]] && [[ ! $DB_PATH =~ \/$ ]]; then
+  # No db file and no trailing slash
+  cmd_opts+=("--db=${DB_PATH}/mail.sqlite")
+elif [[ -n $DB_PATH ]] && [[ ! $DB_PATH =~ \.sqlite$ ]] && [[ $DB_PATH =~ \/$ ]]; then
+  # No db file but with trailing slash
+  cmd_opts+=("--db=${DB_PATH}mail.sqlite")
+else
+  cmd_opts+=("--db=${SENDRIA_DATA_DIR}/mail.sqlite")
+fi
+
+if [[ -n $SMTP_USER ]] && [[ -n $SMTP_PASS ]]; then
+  # Both username and password given
+  htpasswd -bBc ${SENDRIA_DATA_DIR}/.smtp.htpasswd $SMTP_USER $SMTP_PASS
+  # echo "${SMTP_USER}:$(openssl passwd -5 ${SMTP_PASS})" >> ${SENDRIA_DATA_DIR}/.smtp.htpasswd
+  cmd_opts+=("--smtp-auth=${SENDRIA_DATA_DIR}/.smtp.htpasswd")
+elif [[ -z $SMTP_USER ]] && [[ -n $SMTP_PASS ]]; then
+  # Only password given
+  # echo "smtp-user:$(openssl passwd -5 ${SMTP_PASS})" >> ${SENDRIA_DATA_DIR}/.smtp.htpasswd
+  htpasswd -bBc ${SENDRIA_DATA_DIR}/.smtp.htpasswd smtp-user $SMTP_PASS
+  cmd_opts+=("--smtp-auth=${SENDRIA_DATA_DIR}/.smtp.htpasswd")
+elif [[ -n $SMTP_USER ]] && [[ -z $SMTP_PASS ]]; then
+  # Only username given
+  echo "smtp-user:" > ${SENDRIA_DATA_DIR}/.smtp.htpasswd
+  cmd_opts+=("--smtp-auth=${SENDRIA_DATA_DIR}/.smtp.htpasswd")
+fi
+
+if [[ -n $HTTP_USER ]] && [[ -n $HTTP_PASS ]]; then
+  # Both username and password given
+  # echo "${HTTP_USER}:$(openssl passwd -5 ${HTTP_PASS})" >> ${SENDRIA_DATA_DIR}/.http.htpasswd
+  htpasswd -bBc ${SENDRIA_DATA_DIR}/.http.htpasswd $HTTP_USER $HTTP_PASS
+  cmd_opts+=("--http-auth=${SENDRIA_DATA_DIR}/.http.htpasswd")
+elif [[ -z $HTTP_USER ]] && [[ -n $HTTP_PASS ]]; then
+  # Only password given
+  # echo "admin:$(openssl passwd -5 ${HTTP_PASS})" >> ${SENDRIA_DATA_DIR}/.http.htpasswd
+  htpasswd -bBc ${SENDRIA_DATA_DIR}/.http.htpasswd admin $HTTP_PASS
+  cmd_opts+=("--http-auth=${SENDRIA_DATA_DIR}/.http.htpasswd")
+elif [[ -n $HTTP_USER ]] && [[ -z $HTTP_PASS ]]; then
+  # Only username given
+  echo "admin:" > ${SENDRIA_DATA_DIR}/.http.htpasswd
+  cmd_opts+=("--http-auth=${SENDRIA_DATA_DIR}/.http.htpasswd")
+fi
+
+if [[ $DEBUG =~ ^[Tt][Rr][Uu][Ee]$ ]]; then
+  cmd_opts+=("-d")
+fi
+
+if [[ $NO_QUIT =~ ^[Tt][Rr][Uu][Ee]$ ]]; then
+  cmd_opts+=("-n")
+fi 
+
+if [[ $NO_CLEAR =~ ^[Tt][Rr][Uu][Ee]$ ]]; then
+  cmd_opts+=("-c")
+fi
+
+if [[ -n $TEMPLATE_NAME ]]; then
+  cmd_opts+=("--template-header-name=$TEMPLATE_NAME")
+fi
+
+if [[ -n $TEMPLATE_URL ]]; then
+  cmd_opts+=("--template-header-url=$TEMPLATE_URL")
+fi
+
+
+# Run the command that needs running:
+unset SMTP_PASS HTTP_PASS
+echo "${cmd_opts[@]}"
+if [[ -n $LOG_FILE ]]; then
+  sendria --foreground --smtp-ip=0.0.0.0 --http-ip=0.0.0.0 "${cmd_opts[@]}" | tee -a $LOG_FILE
+else
+  sendria --foreground --smtp-ip=0.0.0.0 --http-ip=0.0.0.0 "${cmd_opts[@]}"
+fi
+exit $?


### PR DESCRIPTION
Hi there!

I was in need of using multiple Sendria instances with auth inside of a dockerised, environment, so created a new endpoint script that allows the use of the command line options by passing certain environment variables to the container.  The entrypoint script will then build the sendria command that needs running, and run it.

This allows for the following environment variables to be passed to the container:

- `DB_PATH`: This will accept any of the following (relative to the container)
  - Full path, including the sqlite extension on the filename
  - Path with trailing slash (this will add mail.sqlite)
  - Path without trailing slash (This will add the slash and mail.sqlite to it)
- `SMTP_USER`: This is the smtp username that the user wants.
- `SMTP_PASS`: This is the smtp password that the user wants.
  - If both the username and password are given, then these will be used.
  - If only the username is given, this will be used without a password.
  - If only the password is given, this will use the default username `smtp-user`
  - If neither are given, no auth will be used.
- `HTTP_USER`: This is the  username that the user wants.
  - If both the username and password are given, then these will be used.
  - If only the username is given, this will be used without a password.
  - If only the password is given, this will use the default username `admin`
  - If neither are given, no auth will be used.
- `HTTP_PASS`:  This is the http password that the user wants.
- `DEBUG`: Boolean that switches `sendria` debug on.
- `NO_QUIT`: Boolean that switches `-n` on when true.
- `NO_CLEAR`: Boolean that switches `-c` on when true.
- `TEMPLATE_NAME`: Allows the user to set the name of the template
- `TEMPLATE_URL`: Allows the user to set the url.
- `LOG_FILE`: Accepts a full path to a logfile (inside the container).  This is particularly handy if you want persistent logging.

Note that all of these are optional.  If none are given, the same command is run as is currently run in master.

To make this work, the following changes were made to the Dockerfile:

- Explicitly use the root user for the commands that need it
- Use `bash` instead of `ash` - this allows the BASH_REMATCH functions to work in the entrypoint script.
- Install `apache2-utils` that allow us to generate `htpasswd` files.
- Adding the `SENDRIA_DATA_DIR` environment variable, which is used in the script, to allow for changes if need be, and is handy for persistent volumes.
- Adding the entrypoint script from the `tools` folder, and running that.

This should greatly improve the usability of the docker container, and with all of the data in one directory, allows for persistence if the user so wishes.

An example docker command would be as below (I've built this as `sendria:latest` on my local):

`docker run -d --restart unless-stopped --name sendria-project -p 1080:1080 -p 1025:1025 -v /usr/local/sendria/project/:/home/sendria/data -e HTTP_PASS="4secur3p@ssw0rd!" -e SMTP_USER="project-user" -e SMTP_PASS="4secur3p@ssw0rd!" -e NO_QUIT="TRUE" -e LOG_FILE="/home/sendria/data/log.log" -e TEMPLATE_NAME="My Projects Sendria Sinkhole" -e TEMPLATE_URL="http://172.25.1.174:1080" sendria:latest`

Note that the above uses the default database location, assumes that the http user is admin, and allows the user to clear the mail, but not stop (exit) the container.

Thanks for considering this PR!